### PR TITLE
Add a details view to the newstuff page (and better functionality)

### DIFF
--- a/qml-ui/components/Rating.qml
+++ b/qml-ui/components/Rating.qml
@@ -1,0 +1,73 @@
+/* -*- coding: utf-8 -*-
+******************************************************************************
+ZYNTHIAN PROJECT: Zynthian Qt GUI
+
+Basic star based ratings component (based on the KNewStuff Rating component)
+
+Copyright (C) 2021 Dan Leinir Turthra Jensen <admin@leinir.dk>
+
+******************************************************************************
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+For a full copy of the GNU General Public License see the LICENSE.txt file.
+
+******************************************************************************
+*/
+
+import QtQuick 2.10
+import QtQuick.Layouts 1.4
+import QtQuick.Controls 2.2 as QtControls
+
+import org.kde.kirigami 2.0 as Kirigami
+
+RowLayout
+{
+    id: view
+    property int max: 100
+    property int rating: 0
+    property real starSize: Kirigami.Units.gridUnit
+
+    clip: true
+    spacing: 0
+
+    readonly property var ratingIndex: Math.floor((theRepeater.count*view.rating)/view.max)
+    readonly property var ratingHalf: (theRepeater.count*view.rating)%view.max >= view.max / 2
+
+    Repeater {
+        id: theRepeater
+        model: 5
+        delegate: Kirigami.Icon {
+            Layout.minimumWidth: view.starSize
+            Layout.minimumHeight: view.starSize
+            Layout.preferredWidth: view.starSize
+            Layout.preferredHeight: view.starSize
+
+            source: index < view.ratingIndex
+                ? "rating"
+                : (view.ratingHalf && index == view.ratingIndex
+                    ? "rating-half"
+                    : "rating-unrated")
+            opacity: 1
+        }
+    }
+    Item {
+        Layout.minimumHeight: view.starSize;
+        Layout.minimumWidth: Kirigami.Units.smallSpacing;
+        Layout.maximumWidth: Kirigami.Units.smallSpacing;
+    }
+    QtControls.Label {
+        id: ratingAsText
+        Layout.minimumWidth: view.starSize
+        Layout.minimumHeight: view.starSize
+        text: i18ndc("knewstuff5", "A text representation of the rating, shown as a fraction of the max value", "(%1/%2)", view.rating / 10, view.max / 10)
+    }
+}

--- a/qml-ui/pages/ThemeDownloaderPage.qml
+++ b/qml-ui/pages/ThemeDownloaderPage.qml
@@ -155,7 +155,7 @@ ZComponents.SelectorPage {
                                 opacity: (model.status == NewStuff.ItemsModel.UpdateableStatus) ? 1 : 0;
                                 Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration; } }
                                 anchors {
-                                    bottom: parent.bottom;
+                                    top: parent.top;
                                     right: parent.right;
                                     margins: -Kirigami.Units.smallSpacing;
                                 }
@@ -168,7 +168,7 @@ ZComponents.SelectorPage {
                                 opacity: (model.status == NewStuff.ItemsModel.InstalledStatus) ? 1 : 0;
                                 Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration; } }
                                 anchors {
-                                    bottom: parent.bottom;
+                                    top: parent.top;
                                     right: parent.right;
                                     margins: -Kirigami.Units.smallSpacing;
                                 }
@@ -215,18 +215,20 @@ ZComponents.SelectorPage {
             QQC2.BusyIndicator {
                 id: busyInstallingStuff
                 anchors {
-                    verticalCenter: parent.verticalCenter;
-                    right: parent.right;
-                    rightMargin: Kirigami.Units.largeSpacing + Kirigami.Units.iconSizes.large;
+                    horizontalCenter: parent.horizontalCenter;
+                    bottom: parent.verticalCenter
+                    bottomMargin: Kirigami.Units.largeSpacing
                 }
+                height: Kirigami.Units.gridUnit * 3
+                width: height
                 opacity: (model.status == NewStuff.ItemsModel.InstallingStatus || model.status == NewStuff.ItemsModel.UpdatingStatus) ? 1 : 0;
                 Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration; } }
                 running: opacity > 0;
                 QQC2.Label {
                     anchors {
-                        verticalCenter: parent.verticalCenter;
-                        right: parent.left;
-                        rightMargin: Kirigami.Units.smallSpacing;
+                        horizontalCenter: parent.horizontalCenter;
+                        top: parent.bottom
+                        topMargin: Kirigami.Units.largeSpacing
                     }
                     text: (model.status == NewStuff.ItemsModel.InstallingStatus) ? "Installing" : ((model.status == NewStuff.ItemsModel.UpdatingStatus) ? "Updating" : "");
                     width: paintedWidth;

--- a/qml-ui/pages/ThemeDownloaderPage.qml
+++ b/qml-ui/pages/ThemeDownloaderPage.qml
@@ -54,15 +54,15 @@ ZComponents.SelectorPage {
     }
     contextualActions: [
         Kirigami.Action {
-            enabled: proxyView.currentIndex > -1 && (proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus || proxyView.currentItem.status == NewStuff.ItemsModel.DownloadableStatus)
-            text: proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus ? qsTr("Update") : qsTr("Install"); // if UpdateableStatus, say Update, if UpdateableStatus enabled = false
+            enabled: proxyView.currentItem && (proxyView.currentIndex > -1 && (proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus || proxyView.currentItem.status == NewStuff.ItemsModel.DownloadableStatus || proxyView.currentItem.status == NewStuff.ItemsModel.DeletedStatus))
+            text: proxyView.currentItem ? (proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus ? qsTr("Update") : qsTr("Install")) : ""
             onTriggered: {
                 newStuffModel.installItem(proxyView.currentIndex);
             }
         },
         Kirigami.Action {
-            enabled: proxyView.currentIndex > -1 && (proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus || proxyView.currentItem.status == NewStuff.ItemsModel.InstalledStatus)
-            text: qsTr("Remove");
+            enabled: proxyView.currentItem && (proxyView.currentIndex > -1 && (proxyView.currentItem.status == NewStuff.ItemsModel.UpdateableStatus || proxyView.currentItem.status == NewStuff.ItemsModel.InstalledStatus))
+            text: proxyView.currentItem ? qsTr("Remove") : ""
             onTriggered: {
                 newStuffModel.uninstallItem(proxyView.currentIndex);
             }


### PR DESCRIPTION
This expands the existing proxyView to function as a proper view, which displays a single item with various details like the item's first thumbnail (maybe something we can expand on later), rating (based on the knewstuff one), basic summary, release date, and the version if it's filled out. It further fixes an issue where you couldn't reinstall an item once you'd installed and removed it in the same session (because the status is then deleted, not downloadable)